### PR TITLE
fix piece instance memory sharing

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,18 +1,18 @@
 import 'package:nc_abcs_boardgame_frontend/game/chess_piece.dart';
 
-Map<String, ChessPiece> fenMap = {
-  "k": ChessPiece(PieceType.king, PieceColour.black),
-  "q": ChessPiece(PieceType.queen, PieceColour.black),
-  "b": ChessPiece(PieceType.bishop, PieceColour.black),
-  "n": ChessPiece(PieceType.knight, PieceColour.black),
-  "r": ChessPiece(PieceType.rook, PieceColour.black),
-  "p": ChessPiece(PieceType.pawn, PieceColour.black),
-  "K": ChessPiece(PieceType.king, PieceColour.white),
-  "Q": ChessPiece(PieceType.queen, PieceColour.white),
-  "B": ChessPiece(PieceType.bishop, PieceColour.white),
-  "N": ChessPiece(PieceType.knight, PieceColour.white),
-  "R": ChessPiece(PieceType.rook, PieceColour.white),
-  "P": ChessPiece(PieceType.pawn, PieceColour.white),
+Map<String, ChessPiece Function()> fenMap = {
+  "k": () => ChessPiece(PieceType.king, PieceColour.black),
+  "q": () => ChessPiece(PieceType.queen, PieceColour.black),
+  "b": () => ChessPiece(PieceType.bishop, PieceColour.black),
+  "n": () => ChessPiece(PieceType.knight, PieceColour.black),
+  "r": () => ChessPiece(PieceType.rook, PieceColour.black),
+  "p": () => ChessPiece(PieceType.pawn, PieceColour.black),
+  "K": () => ChessPiece(PieceType.king, PieceColour.white),
+  "Q": () => ChessPiece(PieceType.queen, PieceColour.white),
+  "B": () => ChessPiece(PieceType.bishop, PieceColour.white),
+  "N": () => ChessPiece(PieceType.knight, PieceColour.white),
+  "R": () => ChessPiece(PieceType.rook, PieceColour.white),
+  "P": () => ChessPiece(PieceType.pawn, PieceColour.white),
 };
 
 List<List<ChessPiece?>> decodeFEN(String fenString) {
@@ -25,7 +25,7 @@ List<List<ChessPiece?>> decodeFEN(String fenString) {
       if (int.tryParse(char) != null) {
         rowList.addAll(List.filled(int.parse(char), null));
       } else {
-        rowList.add(fenMap[char]);
+        rowList.add(fenMap[char]!());
       }
     }
 


### PR DESCRIPTION
The map in the function that creates the board was invoking the constructor once when the map was made and then reusing that reference so I changed the map values to lambda functions which invoke the constructor so now each piece is it's own separate instance of the class.