### PR TITLE
Fix promotion menu width

### DIFF
--- a/lib/components/game_screen.dart
+++ b/lib/components/game_screen.dart
@@ -66,7 +66,8 @@ class _GameScreenState extends State<GameScreen> {
         game.promotePawn(int.parse(row), int.parse(column), pieceType);
       });
     }
-    if (message.startsWith("opponent-resigned") || message.startsWith("disconnected")) {
+    if (message.startsWith("opponent-resigned") ||
+        message.startsWith("disconnected")) {
       if (server.myPieces == "white") {
         setState(() {
           game.gameState = GameState.whiteWin;
@@ -308,6 +309,7 @@ class _GameScreenState extends State<GameScreen> {
 
   Container openPromoMenu() {
     return Container(
+      width: widgetWidth,
       color: const Color.fromARGB(255, 39, 3, 0),
       padding: const EdgeInsets.all(30),
       child: Column(


### PR DESCRIPTION
It doesn't take full screen in chrome/linux. Stays the same width as the rest of the widgets i.e. the board width.